### PR TITLE
fixes ruby behavior on added strings with capitals

### DIFF
--- a/lib/wordfilter.rb
+++ b/lib/wordfilter.rb
@@ -18,6 +18,8 @@ module Wordfilter
 		self.init_first_time
 		
 		string_to_test = string.downcase
+		@@blacklist.map!{|badword| badword.downcase}
+		
 		@@blacklist.each{|word|
 			return true if string_to_test.include? word
 		}

--- a/test/wordfilter_test.rb
+++ b/test/wordfilter_test.rb
@@ -21,6 +21,11 @@ class WordfilterTest < Test::Unit::TestCase
 		assert(Wordfilter::blacklisted?("this string was clean!"), "Failed to blacklist a string containing a new bad word.");
 	end
 	
+	def test_added_words_checked_case_insensitively
+		Wordfilter::add_words(['CLEAN']);
+		assert(Wordfilter::blacklisted?("this string was clean!"), "Failed to blacklist a string containing a new bad word because of casing differences.");
+	end
+	
 	def test_clear_blacklist
 		Wordfilter::clear_list
 		refute(Wordfilter::blacklisted?("this string contains the word skank"), "Cleared word list still blacklisting strings.");


### PR DESCRIPTION
The previous implementation didn't do any downcasing on the word list, so added words containing capital letters were never filtered for, so if you added the string `CLEAN`:

``` ruby
Wordfilter::add_words(['CLEAN']);
```

then `Wordfilter::blacklisted?("this string was clean!")` would return false, because it contains `clean`, not `CLEAN`. The JavaScript implementation doesn't seem to have this problem, I think because of the behavior of `toLowerCase`.

This implementation downcases the contents of the blacklist lazily, just before it's consulted. In principle, I'm pretty sure that's the right way to do it, but I have no idea if this implementation is good Ruby -- it may belong in `init_first_time` or equivalent. Seems to work, though!
